### PR TITLE
added Faker library to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 astroid==3.3.8
-coverage==7.6.10
+coverage==7.6.12
 dill==0.3.9
+Faker==36.1.1
 iniconfig==2.0.0
 isort==6.0.0
 mccabe==0.7.0
@@ -12,3 +13,4 @@ pytest==8.3.4
 pytest-cov==6.0.0
 pytest-pylint==0.21.0
 tomlkit==0.13.2
+tzdata==2025.1


### PR DESCRIPTION
Added the "faker" libary with the command "pip install faker" and then used a command pip freeze > requirements.txt to add the library as dependency.